### PR TITLE
Fix item menu jigging

### DIFF
--- a/chrome/content/overlay.xul
+++ b/chrome/content/overlay.xul
@@ -32,8 +32,7 @@
     </popup>
 
     <popup
-        id="zotero-itemmenu"
-        onpopupshowing="ZoteroPane.buildItemContextMenu();">
+        id="zotero-itemmenu">
         <menuitem
             id="zotero-itemmenu-scholarcitations"
             label="&zotero.scholarcitations.update.label;"


### PR DESCRIPTION
I'm not quite sure if `ZoteroPane.buildItemContextMenu();` is necesary for Zotero 5. But after I removed it, the extension works fine and the item context menu does not jig any more.

This should fix #38